### PR TITLE
Mudando forma de abrir o link de contato

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -13,7 +13,11 @@ interface IButtonProps {
 const Button = ({ text }: IButtonProps) => {
   return (
     <button type="button" className={styles.work}>
-      <a href="https://wa.link/1grfbr">
+      <a
+        href="https://wa.link/1grfbr"
+        target="_blank"
+        rel="noreferrer"
+      >
         <span>{text}</span>
 
         <Image


### PR DESCRIPTION
## O que foi feito?
- Adicionando atributo `target="_blank" e `rel="noreferrer"` ao botão de contato.

close #5 